### PR TITLE
Fix installation command and document --decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-# base32go
+# base32
 Golang base32 tool
 
 
-## install
+## Installation
 
 ```bash
-go install github.com/rybus/base32go
+go install github.com/rybus/base32
 ```
 
 add `~/go/bin` to your `$PATH`.
 
-## usage
+## Usage
 
 ```bash
 echo "foo" | base32
 MZXW6===
+
+echo "MZXW6===" | base32 --decode
+"foo"
 ```


### PR DESCRIPTION
Fixes the following:
go install github.com/rybus/base32go
go: finding github.com/rybus/base32go latest
go: downloading github.com/rybus/base32go v0.0.0-20200218210523-6f48065b8240
go: extracting github.com/rybus/base32go v0.0.0-20200218210523-6f48065b8240
go: github.com/rybus/base32go: github.com/rybus/base32go@v0.0.0-20200218210523-6f48065b8240: parsing go.mod:
	module declares its path as: github.com/rybus/base32
	        but was required as: github.com/rybus/base32go